### PR TITLE
feat: graceful shutdown, env vars, build info, unit tests

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,0 +1,42 @@
+---
+name: feature tests
+
+# About security when running the tests and NOT exposing
+# the secrets to externals. Currently Github Actions does
+# NOT expose the secrets if the branch is coming from a forked
+# repository.
+# See: https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/
+# See: https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions
+#
+# An alternate would be to set, pull_request_target but this takes the CI code
+# from master removing the ability to change the code in a PR easily.
+#
+# Aditionally, since 2021 pull requests from new contributors will not
+# trigger workflows automatically but will wait for approval from somebody
+# with write access.
+# See: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
+on: 
+  - pull_request
+  - push
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    container:
+      image: registry.suse.com/bci/golang:1.25
+      options: --user root --privileged
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: lint
+        run: |
+          if [[ ! -z $(gofmt -e -l cmd/ldap-sebin/) ]];
+          then
+            echo "Lint failed"
+            gofmt -e -d cmd/ldap-sebin/
+            exit 1
+          fi
+
+      - name: test
+        run: go test -v ./...

--- a/cmd/ldap-sebin/main.go
+++ b/cmd/ldap-sebin/main.go
@@ -3,51 +3,176 @@ package main
 import (
 	"fmt"
 	"log"
-
+	"net"
 	"os"
+	"os/signal"
+	"syscall"
 
+	"errors"
+	"flag"
 	"github.com/josegomezr/ldap-sebin/internal/handler"
 	"github.com/merlinz01/ldapserver"
 	"gopkg.in/yaml.v3"
+	"strconv"
 	"sync"
 )
 
 type Cfg struct {
+	Verbose        bool   `yaml:"verbose"`
 	Upstream       string `yaml:"upstream-server-url"`
 	ListenAddr     string `yaml:"listen-address"`
-	ListenPort     int    `yaml:"listen-port"`
+	ListenPort     string `yaml:"listen-port"`
 	Certificate    string `yaml:"certificate"`
 	Key            string `yaml:"key"`
 	BaseDn         string `yaml:"base-dn"`
 	FilterTemplate string `yaml:"filter-template"`
+	AllowedBindDn  string `yaml:"allowed-bind-dn"`
 }
 
-func main() {
-	data, err := os.ReadFile("./config.yaml")
-	if err != nil {
-		log.Fatalf("error: %+v", err)
-	}
-
-	cfg := Cfg{}
-	err = yaml.Unmarshal([]byte(data), &cfg)
-	if err != nil {
-		log.Fatalf("error: %+v", err)
-	}
-	fmt.Printf("--- cfg:\n%+v\n\n", cfg)
-
-	if cfg.Upstream == "" || cfg.BaseDn == "" {
-		log.Fatalf("Incomplete upstream configuration.")
-	}
-
-	handler := &handler.Handler{
+func newHandler(cfg *Cfg) *handler.Handler {
+	return &handler.Handler{
+		AllowedBindDn:  cfg.AllowedBindDn,
+		Verbose:        cfg.Verbose,
 		Sessions:       make(map[string]handler.Session),
 		LdapUrl:        cfg.Upstream,
 		BaseDn:         cfg.BaseDn,
 		FilterTemplate: cfg.FilterTemplate,
 		Mutex:          &sync.Mutex{},
 	}
+}
+func newServer(cfg *Cfg) *ldapserver.LDAPServer {
+	handler := newHandler(cfg)
+	return ldapserver.NewLDAPServer(handler)
+}
 
-	s := ldapserver.NewLDAPServer(handler)
+var ReadFile func(string) ([]byte, error) = os.ReadFile
+var ErrBadConfigFile error = errors.New("Bad config file")
+var ErrMissingRequired error = errors.New("Bad config file")
+
+func enrichConfigFromFile(path string, cfg *Cfg) error {
+	data, err := ReadFile(path)
+	if err != nil {
+		return errors.Join(ErrBadConfigFile, err)
+	}
+
+	err = yaml.Unmarshal([]byte(data), cfg)
+
+	if err != nil {
+		return errors.Join(ErrBadConfigFile, err)
+	}
+
+	return nil
+}
+
+func enrichConfigFromEnv(cfg *Cfg) {
+	if val, found := os.LookupEnv("LDAP_SEBIN_UPSTREAM_SERVER_URL"); found {
+		if val == "" {
+			log.Printf("Ignoring empty LDAP_SEBIN_UPSTREAM_SERVER_URL value %q", val)
+		} else {
+			cfg.Upstream = val
+		}
+	}
+	if val, found := os.LookupEnv("LDAP_SEBIN_LISTEN_ADDRESS"); found {
+		if val == "" {
+			log.Printf("Ignoring empty LDAP_SEBIN_LISTEN_ADDRESS value %q", val)
+		} else {
+			cfg.ListenAddr = val
+		}
+	}
+	if val, found := os.LookupEnv("LDAP_SEBIN_CERTIFICATE"); found {
+		if val == "" {
+			log.Printf("Ignoring empty LDAP_SEBIN_CERTIFICATE value %q", val)
+		} else {
+			cfg.Certificate = val
+		}
+	}
+	if val, found := os.LookupEnv("LDAP_SEBIN_KEY"); found {
+		if val == "" {
+			log.Printf("Ignoring empty LDAP_SEBIN_KEY value %q", val)
+		} else {
+			cfg.Key = val
+		}
+	}
+	if val, found := os.LookupEnv("LDAP_SEBIN_BASE_DN"); found {
+		if val == "" {
+			log.Printf("Ignoring empty LDAP_SEBIN_BASE_DN value %q", val)
+		} else {
+			cfg.BaseDn = val
+		}
+	}
+	if val, found := os.LookupEnv("LDAP_SEBIN_FILTER_TEMPLATE"); found {
+		if val == "" {
+			log.Printf("Ignoring empty LDAP_SEBIN_FILTER_TEMPLATE value %q", val)
+		} else {
+			cfg.FilterTemplate = val
+		}
+	}
+	if val, found := os.LookupEnv("LDAP_SEBIN_LISTEN_PORT"); found {
+		if val == "" {
+			log.Printf("Ignoring empty LDAP_SEBIN_LISTEN_PORT value %q", val)
+		} else {
+			if _, err := strconv.Atoi(val); err == nil {
+				cfg.ListenPort = val
+			} else {
+				log.Printf("Ignoring invalid LDAP_SEBIN_LISTEN_PORT value %q", val)
+			}
+		}
+	}
+	if val, found := os.LookupEnv("LDAP_SEBIN_VERBOSE"); found {
+		if val == "" {
+			log.Printf("Ignoring empty LDAP_SEBIN_VERBOSE value")
+		} else {
+			if boolval, err := strconv.ParseBool(val); err == nil {
+				cfg.Verbose = boolval
+			} else {
+				log.Printf("Ignoring invalid LDAP_SEBIN_VERBOSE value %q", val)
+			}
+		}
+	}
+}
+
+func validateCfg(cfg *Cfg) error {
+	if cfg.Upstream == "" || cfg.BaseDn == "" {
+		return errors.Join(ErrMissingRequired, fmt.Errorf("Incomplete upstream configuration."))
+	}
+	return nil
+}
+
+var (
+	Version        = "dev"
+	CommitHash     = "n/a"
+	BuildTimestamp = "n/a" // If we wanna make it reproduceable, this should be commit date
+)
+
+func main() {
+	var nFlag = flag.Bool("v", false, "version")
+	flag.Parse()
+
+	if *nFlag {
+		fmt.Printf("ldap-sebin/%s\nCommit Hash: %s\nCommit Date: %s", Version, CommitHash, BuildTimestamp)
+		os.Exit(0)
+	}
+
+	cfg := &Cfg{}
+	if err := enrichConfigFromFile("./config.yaml", cfg); err != nil {
+		log.Printf("error reading config file: %+v. IGNORING", err)
+	}
+
+	enrichConfigFromEnv(cfg)
+
+	if err := validateCfg(cfg); err != nil {
+		log.Fatalf("Invalid config: %s", err)
+	}
+
+	if cfg.Verbose {
+		log.Printf("Parsed configuration")
+		log.Printf("---")
+		enc := yaml.NewEncoder(os.Stdout)
+		enc.Encode(*cfg)
+		log.Printf("---")
+	}
+
+	s := newServer(cfg)
 
 	listenAddr := cfg.ListenAddr
 	if listenAddr == "" {
@@ -56,28 +181,43 @@ func main() {
 
 	var srvErr error
 
-	if cfg.Certificate == "" || cfg.Key == "" {
-		log.Println("No certificate and/or key configured. Listening for plain text connections. This is NOT secure.")
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-signals
+		fmt.Println()
+		log.Println("Shutting down.")
+		s.Shutdown()
+	}()
 
-		listenPort := cfg.ListenPort
-		if listenPort == 0 {
-			listenPort = 389
-		}
+	// TODO: make this prettier on the validation fn maybe a bool fn "tls
+	// enabled" on the config struct can make it easier.
 
-		srvErr = s.ListenAndServe(fmt.Sprintf("%s:%d", listenAddr, listenPort))
-	} else {
+	listenFunc := s.ListenAndServe
+	var listenPort string
+	if !(cfg.Certificate == "" || cfg.Key == "") {
 		err := s.SetupTLS(cfg.Certificate, cfg.Key)
 		if err != nil {
 			log.Fatalf("TLS configuration failed: %s", err)
 		}
-
-		listenPort := cfg.ListenPort
-		if listenPort == 0 {
-			listenPort = 636
+		listenFunc = s.ListenAndServeTLS
+		if cfg.ListenPort != "" {
+			listenPort = cfg.ListenPort
+		} else {
+			listenPort = "636"
 		}
-
-		srvErr = s.ListenAndServeTLS(fmt.Sprintf("%s:%d", listenAddr, listenPort))
+	} else {
+		if cfg.ListenPort != "" {
+			listenPort = cfg.ListenPort
+		} else {
+			listenPort = "389"
+		}
+		log.Println("No certificate and/or key configured. Listening for plain text connections. This is NOT secure.")
 	}
+
+	serverAddr := net.JoinHostPort(listenAddr, listenPort)
+	log.Printf("Listening to %s", serverAddr)
+	srvErr = listenFunc(serverAddr)
 
 	if srvErr != nil {
 		log.Fatalf("Failed to start LDAP server: %s", srvErr)

--- a/cmd/ldap-sebin/main_test.go
+++ b/cmd/ldap-sebin/main_test.go
@@ -1,0 +1,265 @@
+package main
+
+import (
+	"fmt"
+	ldap "github.com/go-ldap/ldap/v3"
+	"github.com/merlinz01/ldapserver"
+	"log"
+	"strings"
+	"testing"
+	"time"
+)
+
+var upstreamAddr = "127.254.1.1:3389"
+var subjectAddr = "127.0.1.1:3389"
+var upstreamServerUrl = "ldap://" + upstreamAddr
+
+func fakeCfg() *Cfg {
+	return &Cfg{
+		Verbose:        testing.Verbose(),
+		Upstream:       upstreamServerUrl,
+		AllowedBindDn:  "ou=Filterable OU,dc=other,dc=org",
+		ListenAddr:     "",
+		ListenPort:     "",
+		BaseDn:         "ou=Translated Users,dc=example,dc=org",
+		FilterTemplate: "(equivalentUsername=$1)",
+	}
+}
+
+type fakeUpstreamHandler struct {
+	ldapserver.BaseHandler
+	baseDN        string
+	searchResults []string
+}
+
+func (h fakeUpstreamHandler) Bind(conn *ldapserver.Conn, msg *ldapserver.Message, req *ldapserver.BindRequest) {
+	bindDN := req.Name
+	var result *ldapserver.Result
+	if bindDN == fmt.Sprintf("cn=AlwaysCorrect CN,%s", h.baseDN) {
+		result = ldapserver.ResultSuccess.AsResult("SUCCESS!")
+	} else {
+		result = ldapserver.ResultInvalidCredentials.AsResult("Failed auth")
+	}
+	conn.SendResult(msg.MessageID, nil, ldapserver.TypeBindResponseOp, result)
+}
+
+func makeSearchEntry(uid, base string) *ldapserver.SearchResultEntry {
+	cn := fmt.Sprintf("cn=%s CN", uid)
+	return &ldapserver.SearchResultEntry{
+		ObjectName: fmt.Sprintf("%s,%s", cn, base),
+		Attributes: []ldapserver.Attribute{
+			{Description: "cn", Values: []string{cn}},
+			{Description: "uid", Values: []string{uid}},
+			{Description: "givenname", Values: []string{fmt.Sprintf("Given Name %s", uid)}},
+			{Description: "sn", Values: []string{fmt.Sprintf("Last Name %s", uid)}},
+		},
+	}
+}
+
+func (h fakeUpstreamHandler) Search(conn *ldapserver.Conn, msg *ldapserver.Message, req *ldapserver.SearchRequest) {
+	if strings.HasSuffix(req.BaseObject, h.baseDN) {
+		for _, entry := range h.searchResults {
+			conn.SendResult(
+				msg.MessageID,
+				nil,
+				ldapserver.TypeSearchResultEntryOp,
+				makeSearchEntry(entry, h.baseDN),
+			)
+		}
+	}
+	conn.SendResult(msg.MessageID, nil, ldapserver.TypeSearchResultDoneOp, ldapserver.ResultSuccess.AsResult(""))
+}
+
+func shutdown(s *ldapserver.LDAPServer, name string) {
+	if testing.Verbose() {
+		log.Println("Stopping", name)
+	}
+	s.Shutdown()
+}
+
+func listen(s *ldapserver.LDAPServer, name, addr string, ready chan bool) {
+	if testing.Verbose() {
+		log.Println("Starting", name)
+	}
+
+	go func() {
+		time.Sleep(1 * time.Millisecond)
+		ready <- true
+	}()
+	s.ListenAndServe(addr)
+}
+
+func withServer(t *testing.T, handler ldapserver.Handler, fn func(*ldap.Conn)) {
+	t.Helper()
+	ready := make(chan bool, 1)
+
+	upstream := ldapserver.NewLDAPServer(handler)
+	go listen(upstream, "upstream", upstreamAddr, ready)
+	<-ready
+	defer shutdown(upstream, "upstream")
+
+	s := newServer(fakeCfg())
+	go listen(s, "local", subjectAddr, ready)
+	<-ready
+	defer shutdown(s, "local")
+
+	conn, err := ldap.DialURL("ldap://" + subjectAddr)
+	if err != nil {
+		t.Fatalf("Failed: %s", err)
+	}
+	fn(conn)
+}
+
+func TestSearchNoResults(t *testing.T) {
+	handler := &fakeUpstreamHandler{
+		baseDN: "dc=example,dc=org",
+	}
+
+	withServer(t, handler, func(conn *ldap.Conn) {
+		err := conn.Bind("uid=random,ou=Filterable OU,dc=other,dc=org", "password")
+		if err == nil {
+			t.Fatalf("expected failure")
+		}
+		if !ldap.IsErrorWithCode(err, ldap.LDAPResultNoSuchObject) {
+			t.Fatalf("Expected LDAPResultNoSuchObject, got=%q", err)
+		}
+	})
+}
+
+func TestSearchResultsBadPW(t *testing.T) {
+	handler := &fakeUpstreamHandler{
+		baseDN:        "dc=example,dc=org",
+		searchResults: []string{"random"},
+	}
+
+	withServer(t, handler, func(conn *ldap.Conn) {
+		err := conn.Bind("uid=random,ou=Filterable OU,dc=other,dc=org", "password")
+		if err == nil {
+			t.Fatalf("expected failure")
+		}
+		if !ldap.IsErrorWithCode(err, ldap.LDAPResultInvalidCredentials) {
+			t.Fatalf("Expected LDAPResultNoSuchObject, got=%q", err)
+		}
+	})
+}
+
+func TestSearchOutsideOfAllowedDN(t *testing.T) {
+	handler := &fakeUpstreamHandler{
+		baseDN: "ou=Translated Users,dc=example,dc=org",
+	}
+
+	withServer(t, handler, func(conn *ldap.Conn) {
+		err := conn.Bind("uid=who-cares-this-has-to-fail,ou=NotYourOU,dc=wooooooo,dc=org", "password")
+		if err == nil {
+			t.Fatalf("expected failure")
+		}
+		if !ldap.IsErrorWithCode(err, ldap.LDAPResultInsufficientAccessRights) {
+			t.Fatalf("Expected LDAPResultInsufficientAccessRights, got=%q", err)
+		}
+	})
+}
+
+func TestSearchResultsCorrectPW(t *testing.T) {
+	handler := &fakeUpstreamHandler{
+		baseDN:        "ou=Translated Users,dc=example,dc=org",
+		searchResults: []string{"AlwaysCorrect"},
+	}
+
+	withServer(t, handler, func(conn *ldap.Conn) {
+		err := conn.Bind("uid=this-must-work,ou=Filterable OU,dc=other,dc=org", "password")
+		if err != nil {
+			t.Fatalf("failed: %s", err)
+		}
+	})
+}
+
+func TestConfigFileEmpty(t *testing.T) {
+	orig := ReadFile
+	defer func() { ReadFile = orig }()
+	ReadFile = func(string) ([]byte, error) {
+		return []byte("---"), nil
+	}
+	cfg := &Cfg{}
+	err := enrichConfigFromFile("", cfg)
+	if err != nil {
+		t.Fatalf("failed: %s", err)
+	}
+}
+
+func TestConfigFileRequired(t *testing.T) {
+	orig := ReadFile
+	defer func() { ReadFile = orig }()
+	ReadFile = func(string) ([]byte, error) {
+		return []byte(
+			"---" + "\n" +
+				`upstream-server-url: ldap://your-ldap-server.example.com` + "\n" +
+				`base-dn: "ou=Fun User Accounts,dc=company,dc=tld"` + "\n" +
+				`...` + "\n",
+		), nil
+	}
+	cfg := &Cfg{}
+	err := enrichConfigFromFile("", cfg)
+	if err != nil {
+		t.Fatalf("failed: %s", err)
+	}
+
+	if cfg.Upstream != "ldap://your-ldap-server.example.com" {
+		t.Fatalf("failed pulling cfg from yaml file. got=%q", cfg.Upstream)
+	}
+
+	if cfg.BaseDn != "ou=Fun User Accounts,dc=company,dc=tld" {
+		t.Fatalf("failed pulling cfg from yaml file. got=%q", cfg.BaseDn)
+	}
+}
+
+func TestConfigEnvs(t *testing.T) {
+	cfg := &Cfg{}
+	enrichConfigFromEnv(cfg)
+
+	if cfg.Upstream != "" {
+		t.Fatalf("failed pulling cfg from yaml file. got=%q", cfg.Upstream)
+	}
+
+	if cfg.BaseDn != "" {
+		t.Fatalf("failed pulling cfg from yaml file. got=%q", cfg.BaseDn)
+	}
+}
+
+func TestValidateCfg(t *testing.T) {
+	cfgs := []struct {
+		cfg         Cfg
+		shouldError bool
+	}{
+		{
+			cfg: Cfg{
+				Upstream: "",
+				BaseDn:   "",
+			},
+			shouldError: true,
+		},
+		{
+			cfg: Cfg{
+				Upstream: "ldap://something",
+				BaseDn:   "",
+			},
+			shouldError: true,
+		},
+		{
+			cfg: Cfg{
+				Upstream: "ldap://something",
+				BaseDn:   "dc=a,dc=b",
+			},
+			shouldError: false,
+		},
+	}
+
+	for _, expectation := range cfgs {
+		if err := validateCfg(&expectation.cfg); (err == nil) == expectation.shouldError {
+			if expectation.shouldError {
+				t.Fatalf("Failed, expected error: %+v", expectation.cfg)
+			} else {
+				t.Fatalf("Failed, unexpected error: %+v", expectation.cfg)
+			}
+		}
+	}
+}

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -16,6 +16,8 @@ import (
 type Handler struct {
 	ldapserver.BaseHandler
 
+	Verbose        bool
+	AllowedBindDn  string
 	Sessions       map[string]Session
 	LdapUrl        string
 	BaseDn         string
@@ -29,7 +31,9 @@ type Session struct {
 }
 
 func (h Handler) dial() (*ldap.Conn, error) {
-	fmt.Printf("Starting connection to %s\n", h.LdapUrl)
+	if h.Verbose {
+		fmt.Printf("Starting connection to %s\n", h.LdapUrl)
+	}
 	return ldap.DialURL(h.LdapUrl)
 }
 
@@ -43,7 +47,9 @@ func (h Handler) getSession(conn *ldapserver.Conn) (Session, error) {
 	if !ok { // open a new server connection if not
 		l, err := h.dial()
 		if err != nil {
-			fmt.Printf("ERR: %s\n", err.Error())
+			if h.Verbose {
+				fmt.Printf("ERR: %s\n", err.Error())
+			}
 			return Session{}, err
 		}
 		// l.Debug = true
@@ -55,72 +61,94 @@ func (h Handler) getSession(conn *ldapserver.Conn) (Session, error) {
 	return s, nil
 }
 
+func getFirstDNComponent(bindDN string) string {
+	searchFilter, _, _ := strings.Cut(bindDN, ",")
+	_, searchFilter, _ = strings.Cut(searchFilter, "=")
+	return searchFilter	
+}
+
 func (h Handler) Bind(conn *ldapserver.Conn, msg *ldapserver.Message, req *ldapserver.BindRequest) {
-	bindDN := req.Name
-	if bindDN == "" {
-		log.Printf("Invalid bind with empty DN")
+	result := ldapserver.ResultOperationsError.AsResult("Unknown Error")
+	defer func(){
+		if h.Verbose {
+			fmt.Printf("Bind result: %+v\n", result)
+		}
+		conn.SendResult(msg.MessageID, nil, ldapserver.TypeBindResponseOp, result)
+	}()
 
-		conn.SendResult(msg.MessageID, nil, ldapserver.TypeBindResponseOp, ldapserver.ResultInvalidCredentials.AsResult("Bind with empty DN is not allowed."))
-
+	if !strings.HasSuffix(req.Name, h.AllowedBindDn) {
+		result = ldapserver.ResultInsufficientAccessRights.AsResult("hey! that's trespassing")
 		return
 	}
 
-	bindSimplePw := req.Credentials.(string)
+	if req.Name == "" {
+		if h.Verbose {
+			log.Printf("Invalid bind with empty DN")
+		}
 
-	searchFilter := bindDN
-	searchFilter, _, _ = strings.Cut(searchFilter, ",")
-	_, searchFilter, _ = strings.Cut(searchFilter, "=")
+		result = ldapserver.ResultInvalidCredentials.AsResult("Bind with empty DN is not allowed.")
+		return
+	}
 
-	searchFilter = strings.ReplaceAll(h.FilterTemplate, "$1", searchFilter)
-	log.Printf("input bind-dn: %+v\n", bindDN)
-	log.Printf("search-filter: %+v\n", searchFilter)
+	searchFilter := strings.ReplaceAll(h.FilterTemplate, "$1", getFirstDNComponent(req.Name))
+
+	if h.Verbose {
+		log.Printf("input bind-dn: %+v\n", req.Name)
+		log.Printf("search-filter: %+v\n", searchFilter)
+	}
 
 	search := ldap.NewSearchRequest(
 		h.BaseDn,
 		ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 5, 0, false,
 		searchFilter,
 		[]string{"dn"},
-		nil)
+		nil,
+	)
 
 	s, err := h.getSession(conn)
 	if err != nil {
-		conn.SendResult(msg.MessageID, nil, ldapserver.TypeBindResponseOp, ldapserver.ResultOperationsError.AsResult(""))
-
+		result = ldapserver.ResultOperationsError.AsResult("Upstream connection error")
 		return
 	}
-	log.Printf("Performing search: %+v ", search)
+	if h.Verbose {
+		log.Printf("Performing search: %+v ", search)
+	}
 
 	sr, err := s.ldap.Search(search)
 	if err != nil {
-		conn.SendResult(msg.MessageID, nil, ldapserver.TypeBindResponseOp, ldapserver.ResultOperationsError.AsResult(""))
-
+		result = ldapserver.ResultOperationsError.AsResult(fmt.Sprintf("error: %s", err))
 		return
 	}
 
 	if len(sr.Entries) == 0 {
-		conn.SendResult(msg.MessageID, nil, ldapserver.TypeBindResponseOp, ldapserver.ResultNoSuchObject.AsResult(""))
-
+		result = ldapserver.ResultNoSuchObject.AsResult("Not found")
 		return
 	}
 
+	bindSimplePw := req.Credentials.(string)
 	for _, entry := range sr.Entries {
 		newDn := entry.DN
-		log.Printf("Search matched DN: %+v ", newDn)
-
+		if h.Verbose {
+			log.Printf("Search matched DN: %+v ", newDn)
+		}
 		if err := s.ldap.Bind(newDn, bindSimplePw); err != nil {
-			log.Printf("Failed auth, continuing")
+			if h.Verbose {
+				log.Printf("Failed auth with %s, continuing\n", newDn)
+			}
 			continue
 		}
 
-		log.Printf("Auth succeeded!: %+v ", newDn)
-		conn.SendResult(msg.MessageID, nil, ldapserver.TypeBindResponseOp, ldapserver.ResultSuccess.AsResult(""))
-
+		if h.Verbose {
+			log.Printf("Auth succeeded with: %+v ", newDn)
+		}
+		result = ldapserver.ResultSuccess.AsResult("Success")
 		return
 	}
 
-	log.Printf("Failed auth against all matched entries")
-	conn.SendResult(msg.MessageID, nil, ldapserver.TypeBindResponseOp, ldapserver.ResultInvalidCredentials.AsResult(""))
-
+	if h.Verbose {
+		log.Printf("Failed auth against all matched entries")
+	}
+	result = ldapserver.ResultInvalidCredentials.AsResult("Could not bind with the given password")
 	return
 }
 


### PR DESCRIPTION
- Graceful shutdown with Control+C
- Support and unit tests for Environment Variables for configuration.
  + Environment variables will always overwrite whatever is defined on the config file.
- Unit tests and E2E tests for the whole flow
  + A personal feat of engineering (it's probably heresy) having a fake maleable LDAP upstream server to test the translation capabilities.
- New feature: Accept binds only for specific base DN's.
  - Binds coming from other DN's are rejected gracefully without triggering a connection to upstream.
- New feature: Verbose mode. Prints all debugging information
- Build information variables for packaging purposes.
- '-v' flag to show packaging information (and a very basic "just works" test after compilation).
- GitHub action pipeline for testing our changes on commit/PRs